### PR TITLE
Add http monitoring checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG=7
 FROM datadog/agent:${TAG}
 
-ADD checks.d /etc/datadog-agent/checks.d/
-ADD conf.d /etc/datadog-agent/conf.d/
+COPY checks.d /etc/datadog-agent/checks.d/
+COPY conf.d /etc/datadog-agent/conf.d/
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # docker-datadog
 
 a docker image containing datadog
+
+To use the same building process as the Jenkins infrastructure does, please look at [this](https://github.com/jenkins-infra/pipeline-library/tree/master/resources/io/jenkins/infra/docker)

--- a/conf.d/http_check.d/jenkins.yaml
+++ b/conf.d/http_check.d/jenkins.yaml
@@ -1,0 +1,208 @@
+init_config:
+
+instances:
+  - name: accounts.jenkins.io
+    url: https://accounts.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: ci.jenkins.io
+    url: https://ci.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: issues.jenkins.io
+    url: https://issues.jenkins.io/status
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: javadoc.io
+    url: http://javadoc.jenkins.io/script.js
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: jenkins.io
+    url: https://www.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: pkg.jenkins.io
+    url: https://pkg.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: plugins.jenkins.io
+    url: https://plugins.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: rating.jenkins.io
+    url: https://rating.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    http_response_status_code: 403
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: repo.jenkins-ci.org
+    url: https://repo.jenkins-ci.org/api/system/ping
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins-ci.org
+  - name: reports.jenkins.io
+    url: https://reports.jenkins.io/artifactory-ldap-users-report.json
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: status.jenkins.io
+    url: https://status.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: updates.jenkins.io
+    url: https://updates.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: updates.jenkins-ci.org
+    url: https://updates.jenkins-ci.org
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins-ci.org
+  - name: uplink.jenkins.io
+    url: https://uplink.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: usage.jenkins.io
+    url: https://usage.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io
+  - name: wiki.jenkins-ci.org
+    url: https://wiki.jenkins-ci.org/status
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins-ci.org
+  - name: wiki.jenkins.io
+    url: https://wiki.jenkins.io/status
+    timeout: 10
+    threshold: 3
+    window: 5
+    collect_response_time: true
+    check_certificate_expiration: true
+    days_warning: 30
+    days_critical: 10
+    tags:
+      - production
+      - jenkins.io

--- a/conf.d/http_check.d/mirrors.yaml
+++ b/conf.d/http_check.d/mirrors.yaml
@@ -1,0 +1,135 @@
+init_config:
+
+instances:
+  - name: ftp.belnet.be
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://ftp.belnet.be/pub/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: mirror.serverion.com
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://mirror.serverion.com/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: mirror.esuni.jp
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://mirror.esuni.jp/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: mirrors.tuna.tsinghua.edu.cn
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://mirrors.tuna.tsinghua.edu.cn/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: mirror.xmission.com
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://mirror.xmission.com/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: ftp-nyc.osuosl.org
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://ftp-nyc.osuosl.org/pub/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror:ftp-nyc.osuosl.org
+  - name: ftp-chi.osuosl.org
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://ftp-chi.osuosl.org/pub/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: ftp.yz.yamagata-u.ac.jp
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://ftp.yz.yamagata-u.ac.jp/pub/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: mirror.gruenehoelle.nl
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://mirror.gruenehoelle.nl/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: ftp.halifax.rwth-aachen.de
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://ftp.halifax.rwth-aachen.de/jenkins/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror
+  - name: mirror.azure.jenkins.io
+    timeout: 10
+    threshold: 3
+    window: 5
+    days_warning: 10
+    days_critical: 5
+    url: https://mirror.azure.jenkins.io/TIME
+    method: get
+    collect_response_time: true
+    check_certificate_expiration: true
+    tags:
+      - mirror


### PR DESCRIPTION
Add http monitoring endpoint directly in the docker image as the configuration done on the helm chart doesn't work.
Initial work as been done [here](https://github.com/jenkins-infra/charts/pull/891).

The problem is that helm insert the configuration in `/etc/datadog-agent/conf.d/` which doesn't work instead of `/etc/datadog-agent/conf.d/http_check.d`


Signed-off-by: Olivier Vernin <olivier@vernin.me>