### PR TITLE
Add deprecation and archival warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # docker-datadog
 
+> **Warning**
+> This image is deprecated and unused since https://github.com/jenkins-infra/kubernetes-management/pull/3919, hence this repository archival.
+
 a docker image containing datadog
 
 To use the same building process as the Jenkins infrastructure does, please look at [this](https://github.com/jenkins-infra/pipeline-library/tree/master/resources/io/jenkins/infra/docker)


### PR DESCRIPTION
This repo is not needed since https://github.com/jenkins-infra/kubernetes-management/pull/3919, this PR puts a corresponding warning fancy blockquote in the README.

Related: https://github.com/jenkins-infra/helpdesk/issues/3558